### PR TITLE
Remove single line comments before executing code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,14 +48,54 @@ export function activate(context: vscode.ExtensionContext) {
 				selection === undefined || selection.anchor.isEqual(selection.active) ?
 					editor.document.getText() : editor.document.getText(selection);
 
-			return text
-				.replace(/<\?php/, '')
-				.replace(/\r?\n/g, '')
-				.replace(/\ +/g, ' ')
-				.replace(/"+/g, '\\"')
-				.replace(/\$+/g, "\\$");
+			return prepareCode(text);
 		}
 	}
+
+    function prepareCode(text: string) {
+        const textWithoutComments = removeComments(text);
+    
+        return textWithoutComments
+        .replace(/<\?php/, '')
+        .replace(/\r?\n/g, '')
+        .replace(/\ +/g, ' ')
+        .replace(/"+/g, '\\"')
+        .replace(/\$+/g, "\\$");
+    }
+    
+    function removeComments(text: string) {
+        const commentInStringRanges = getMatchRanges(text, /(['"])(.|\n)*?(?<!\\)\1/g);
+        const commentRanges = getMatchRanges(text, /\/\/.*/g).reverse();
+    
+        for (const commentRange of commentRanges) {
+            if (isRangeCollidingWithRanges(commentRange, commentInStringRanges)) {
+                continue;
+            }
+    
+            text = text.slice(0, commentRange[0]) + text.slice(commentRange[1]);
+        }
+        
+        return text;
+    }
+    
+    function getMatchRanges(text: string, regex: RegExp) {
+        const ranges: Array<Array<number>> = [];
+    
+        text.replace(regex, (...args) => {
+            const match = args[0];
+            const offset = args[args.length - 2];
+
+            ranges.push([offset, offset + match.length]);
+        });
+    
+        return ranges;
+    }
+    
+    function isRangeCollidingWithRanges(targetRange: Array<number>, ranges: Array<Array<number>>) {
+        return ranges.some((range: Array<number>) => {
+            return !(targetRange[1] <= range[0] || targetRange[0] >= targetRange[1]);
+        });
+    }
 
 	context.subscriptions.push(...disposables);
 }


### PR DESCRIPTION
I noticed that whenever I ran tinker this and my file had a single line comment, pretty much all of the remaining code got ignored since one of the steps consisted on removing new line characters from the code before running it.

This function for example:
```php
<?php

function f() {
    //  filter this line
    echo 1 . PHP_EOL;// filter this comment
    echo '// echo this string' . PHP_EOL;
    echo 'ignore double slashes on multi //
    line//
    string//' . PHP_EOL;
}

f();
```
became this
```php
function f() { // filter this line echo 1 . PHP_EOL;// filter this comment echo '// echo this string' . PHP_EOL; echo 'ignore double slashes on multi // line// string//' . PHP_EOL;}f();
```

So I eventually came up with a implementation that removes the single line comments before anything else, it even handles the edge case where double slashes are actual text inside PHP strings, in which case that would not be a comment so we don't want to change it. Using the same input as before, this is the output after using my updated code:
```php
function f() { echo 1 . PHP_EOL; echo '// echo this string' . PHP_EOL; echo 'ignore double slashes on multi // line// string//' . PHP_EOL;}f();
```